### PR TITLE
xsgetn: Fix early return

### DIFF
--- a/src/impl/basic_socketbuf.cc
+++ b/src/impl/basic_socketbuf.cc
@@ -230,7 +230,13 @@ namespace swoope {
 		} else {
 			s = std::copy(this->gptr(), this->gptr() + avail, s);
 			this->gbump(static_cast<std::size_t>(avail));
-			result = avail + read(s, n - avail);
+			result = avail;
+			while (result < n) {
+				std::streamsize got = read(s, n - result);
+				if (got <= 0) break;
+				s += got;
+				result += got;
+			}
 		}
 		return result;
 	}


### PR DESCRIPTION
xsgetn is [obliged](https://en.cppreference.com/w/cpp/io/basic_streambuf/sgetn) to read the entire amount requested by the caller unless the stream ends:

> Reads count characters from the input sequence and stores them into a character array pointed to by s. The characters are read as if by repeated calls to [sbumpc()](https://en.cppreference.com/w/cpp/io/basic_streambuf/sbumpc). That is, if less than count characters are immediately available, the function calls [uflow()](https://en.cppreference.com/w/cpp/io/basic_streambuf/uflow) to provide more until Traits::eof() is returned.